### PR TITLE
Update views-view-fields--neuro-research-emphasis.tpl.php

### DIFF
--- a/templates/views-view-fields--neuro-research-emphasis.tpl.php
+++ b/templates/views-view-fields--neuro-research-emphasis.tpl.php
@@ -38,25 +38,23 @@ $node_path = drupal_lookup_path('alias','node/'.$row->nid);
 switch ($row->node_type) {
   case 'stanford_event':
     $output = '<div class="masonry-event">';
-    if (isset($row->field_field_stanford_event_image[0])) {
-      $output .= '<div>' . drupal_render($row->field_field_stanford_event_image[0]['rendered']) . '</div>';
-    }
-    $output .= '<div class="postcard-left">';
     $output .= '<div class="date-stacked">';
     $output .= '<div class="date-month">' . drupal_render($row->field_field_stanford_event_datetime_2[0]['rendered']) . '</div>';
     $output .= '<div class="date-day">' . drupal_render($row->field_field_stanford_event_datetime_3[0]['rendered']) . '</div>';
     $output .= '</div>'; //end date-stacked
+    if (isset($row->field_field_stanford_event_image[0])) {
+      $output .= '<div>' . drupal_render($row->field_field_stanford_event_image[0]['rendered']) . '</div>';
+    }
     $output .= '<div class="well">';
     $output .= '<div>'; //undocumented div
     $output .= '<div class="type-event">Event</div>';
     $output .= '<div class="event-date-long descriptor">' . drupal_render($row->field_field_stanford_event_datetime[0]['rendered']) . ' ' . drupal_render($row->field_field_stanford_event_datetime_1[0]['rendered']) . '</div>';
     $output .= '<div class="event-title normal-link"><h3>' . $row->node_title . '</h3></div>';
     $output .= '</div>'; //end undocumented div
-    $output .= '</div>'; //end well
-    $output .= '</div>';  //end postcard-left
     if ($node_acces) {
       $output .= '<div class="edit-link"><a href="/node/' . $row->nid . '/edit?destination=' . $node_path . '">Edit</a></div>';
     }
+    $output .= '</div>'; //end well    
     $output .= '</div>'; //end masonry-event
     break;
   case 'stanford_news_item':
@@ -68,16 +66,17 @@ switch ($row->node_type) {
     $output .= '<div class="type-event">News - ' . drupal_render($row->field_field_s_news_date[0]['rendered'])  . '</div>';
     $output .= '<div class="descriptor">' . drupal_render($row->field_field_s_news_source[0]['rendered']) . '</div>';
     $output .= '<div class="normal-link"><h3>' . $row->node_title . '</h3></div>';
-    $output .= '</div>'; //end well
     if ($node_acces) {
       $output .= '<div class="edit-link"><a href="/node/' . $row->nid . '/edit?destination=' . $node_path . '">Edit</a></div>';
     }
+    $output .= '</div>'; //end well
     $output .= '</div>'; //end masonry-news
     break;
   case 'stanford_announcement':
     if ($row->field_field_s_announce_tweet[0]['raw']['value'] == 1) {
       //This is a tweet
       $output = '<div class="masonry-tweet well">';
+      $output .= '<div class="descriptor">Twitter ' . drupal_render($row->field_field_s_announcement_date[0]['rendered']) . '</div>';
       $output .= '<div>' . drupal_render($row->field_body[0]['rendered']) . '</div>';
       if ($node_acces) {
         $output .= '<div class="edit-link"><a href="/node/' . $row->nid . '/edit?destination=' . $node_path . '">Edit</a></div>';
@@ -93,10 +92,10 @@ switch ($row->node_type) {
       $output .= '<div class="descriptor">Announcement ' . drupal_render($row->field_field_s_announcement_date[0]['rendered']) . '</div>';
       $output .= '<div class="normal-link"><h3>' . $row->node_title . '</h3></div>';
       $output .= '<div>' . drupal_render($row->field_body[0]['rendered']) . '</div>';
-      $output .= '</div>'; //end well
       if ($node_acces) {
         $output .= '<div class="edit-link"><a href="/node/' . $row->nid . '/edit?destination=' . $node_path . '">Edit</a></div>';
       }
+      $output .= '</div>'; //end well
       $output .= '</div>'; //end masonry-announcement
     }
     break;
@@ -108,10 +107,10 @@ switch ($row->node_type) {
     $output .= '<div class="well">';
     $output .= '<div class="descriptor">Funded Research ' . drupal_render($row->field_field_s_fund_research_type[0]['rendered']) . '</div>';
     $output .= '<div class="normal-link"><h3>' . $row->node_title . '</h3></div>';
-    $output .= '</div>'; //end well
     if ($node_acces) {
       $output .= '<div class="edit-link"><a href="/node/' . $row->nid . '/edit?destination=' . $node_path . '">Edit</a></div>';
     }
+    $output .= '</div>'; //end well
     $output .= '</div>'; //end masonry-research
 }
 print $output;


### PR DESCRIPTION
Edits to case 'stanford_event'
+ moved the date-stacked div above the image output so that we can style the date stack over the image.
+ moved edit-link to inside the div with the well so that the edit button placement would be consistent.
+ moved div with well class out of postcard-left so that the well would span the entire width of the card. 
+ removed postcard-left div

case stanford_annoucnment tweet
+ added descriptor div to identify card as Twitter used drupal_render($row->field_field_s_announcement_date[0]['rendered']) for date.

case 'stanford_announcement' else
+ moved edit-link to inside well div.

case 'stanford_news'
+ moved edit-link to inside well

case 'stanford_funded_research'
+ moved edit-link to inside well

@boznik I was not able to make the following changes:
Please make these changes or advise:
+ add summary field to the case stanford_funded_research
+ fix the links to the edit node buttons. Currently they are missing the site-name in the path (jumpstart-neuro)
